### PR TITLE
Cherry pick: Add backend CD pipeline

### DIFF
--- a/.github/workflows/backend-CD.yml
+++ b/.github/workflows/backend-CD.yml
@@ -1,0 +1,25 @@
+name: Backend CD
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download build artifact
+      uses: actions/download-artifact@v2
+      with: 
+        name: backend-release-master
+    - name: Publish
+      run: dotnet publish --no-build -c Release -o my-release
+    - name: 'Deploy to Azure'
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: mywarehouseapi
+        publish-profile: ${{ secrets.AZURE_PUBLISHING_PROFILE }}
+        package: './my-release'


### PR DESCRIPTION
(cherry picked from commit 5b75ff7e95173d0aee0aa191d95d362129e40e04)

Just because it's literally impossible to see and trigger workflows that don't yet exist in the default branch. This is absolutely NOT fun.